### PR TITLE
Add functionality for "auth and commit", or "auth and capture": Add t…

### DIFF
--- a/src/main/java/io/paymenthighway/PaymentAPI.java
+++ b/src/main/java/io/paymenthighway/PaymentAPI.java
@@ -121,8 +121,12 @@ public class PaymentAPI implements Closeable {
 
   /**
    * Payment Highway Transaction Commit Request
+   * Used to commit (capture) the transaction.
+   * In order to find out the result of the transaction without committing it, use Transaction Result request instead.
    *
    * @param transactionId
+   * @param amount The amount to commit, must be less or equal than the initial transaction amount
+   * @param currency The original transaction currency
    * @return CommitTransactionResponse
    * @throws HttpResponseException
    * @throws AuthenticationException
@@ -133,6 +137,21 @@ public class PaymentAPI implements Closeable {
     CommitTransactionRequest commitRequest = new CommitTransactionRequest(amount, currency);
 
     return paymentApi.commitTransaction(transactionId, commitRequest);
+  }
+
+  /**
+   * Payment Highway Transaction Result Request
+   * Used to find out whether or not an uncommitted transaction succeeded, without actually committing (capturing) it.
+   *
+   * @param transactionId
+   * @return TransactionResultResponse
+   * @throws HttpResponseException
+   * @throws AuthenticationException
+   * @throws IOException
+   */
+  public TransactionResultResponse transactionResult(UUID transactionId) throws IOException {
+
+    return paymentApi.transactionResult(transactionId);
   }
 
   /**

--- a/src/main/java/io/paymenthighway/connect/PaymentAPIConnection.java
+++ b/src/main/java/io/paymenthighway/connect/PaymentAPIConnection.java
@@ -35,7 +35,7 @@ public class PaymentAPIConnection implements Closeable {
   private static final String USER_AGENT = "PaymentHighway Java Lib";
   private static final String METHOD_POST = "POST";
   private static final String METHOD_GET = "GET";
-  private static final String SPH_API_VERSION = "20160307";
+  private static final String SPH_API_VERSION = "20160630";
 
   private String serviceUrl = "";
   private String signatureKeyId = null;
@@ -123,6 +123,18 @@ public class PaymentAPIConnection implements Closeable {
 
     JsonParser jpar = new JsonParser();
     return jpar.mapResponse(response, CommitTransactionResponse.class);
+  }
+
+  public TransactionResultResponse transactionResult(UUID transactionId) throws IOException {
+
+    final String paymentUri = "/transaction/";
+    final String actionUri = "/result";
+    String transactionResultUrl = paymentUri + transactionId + actionUri;
+
+    String response = executeGet(transactionResultUrl, createNameValuePairs());
+
+    JsonParser jpar = new JsonParser();
+    return jpar.mapResponse(response, TransactionResultResponse.class);
   }
 
   public TransactionStatusResponse transactionStatus(UUID transactionId) throws IOException {

--- a/src/main/java/io/paymenthighway/json/JsonParser.java
+++ b/src/main/java/io/paymenthighway/json/JsonParser.java
@@ -53,6 +53,11 @@ public class JsonParser {
   }
 
   @Deprecated
+  public TransactionResultResponse mapTransactionResultResponse(String json) {
+    return mapResponse(json, TransactionResultResponse.class);
+  }
+
+  @Deprecated
   public TokenizationResponse mapTokenizationResponse(String json) {
     return mapResponse(json, TokenizationResponse.class);
   }

--- a/src/main/java/io/paymenthighway/json/JsonParser.java
+++ b/src/main/java/io/paymenthighway/json/JsonParser.java
@@ -53,11 +53,6 @@ public class JsonParser {
   }
 
   @Deprecated
-  public TransactionResultResponse mapTransactionResultResponse(String json) {
-    return mapResponse(json, TransactionResultResponse.class);
-  }
-
-  @Deprecated
   public TokenizationResponse mapTokenizationResponse(String json) {
     return mapResponse(json, TokenizationResponse.class);
   }

--- a/src/main/java/io/paymenthighway/model/response/AbstractTransactionOutcomeResponse.java
+++ b/src/main/java/io/paymenthighway/model/response/AbstractTransactionOutcomeResponse.java
@@ -1,0 +1,57 @@
+package io.paymenthighway.model.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+/**
+ * Common response for e.g. Commit and Result transaction requests.
+ */
+abstract public class AbstractTransactionOutcomeResponse extends Response {
+
+  @JsonProperty("card_token")
+  UUID cardToken;
+  PartialCard card;
+  Customer customer;
+  @JsonProperty("cardholder_authentication")
+  String cardholderAuthentication;
+  @JsonProperty("filing_code")
+  protected String filingCode;
+  @JsonProperty("committed")
+  protected Boolean committed;
+  @JsonProperty("committed_amount")
+  protected String committedAmount;
+
+  public UUID getCardToken() {
+    return cardToken;
+  }
+
+  public PartialCard getCard() {
+    return this.card;
+  }
+
+  public Customer getCustomer() {
+    return customer;
+  }
+
+  public String getCardholderAuthentication() {
+    return cardholderAuthentication;
+  }
+
+  public String getFilingCode() {
+    return filingCode;
+  }
+
+  public Boolean getCommitted() {
+    return committed;
+  }
+
+  /**
+   * @return Committed amount or null if transaction not committed
+   */
+  public String getCommittedAmount() {
+    return committedAmount;
+  }
+
+
+}

--- a/src/main/java/io/paymenthighway/model/response/CommitTransactionResponse.java
+++ b/src/main/java/io/paymenthighway/model/response/CommitTransactionResponse.java
@@ -1,40 +1,10 @@
 package io.paymenthighway.model.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.UUID;
-
 /**
- * Commit Transaction request POJO
+ * Commit Transaction response POJO
+ * Commit Transaction is used to commit (capture) the transaction. In order to find out the result of the transaction
+ * without committing it, use the Transaction Result request instead.
  */
-public class CommitTransactionResponse extends Response {
+public class CommitTransactionResponse extends AbstractTransactionOutcomeResponse {
 
-  @JsonProperty("card_token")
-  UUID cardToken;
-  PartialCard card;
-  Customer customer;
-  @JsonProperty("cardholder_authentication")
-  String cardholderAuthentication;
-  @JsonProperty("filing_code")
-  private String filingCode;
-
-  public UUID getCardToken() {
-    return cardToken;
-  }
-
-  public PartialCard getCard() {
-    return this.card;
-  }
-
-  public Customer getCustomer() {
-    return customer;
-  }
-
-  public String getCardholderAuthentication() {
-    return cardholderAuthentication;
-  }
-
-  public String getFilingCode() {
-    return filingCode;
-  }
 }

--- a/src/main/java/io/paymenthighway/model/response/TransactionResultResponse.java
+++ b/src/main/java/io/paymenthighway/model/response/TransactionResultResponse.java
@@ -1,0 +1,8 @@
+package io.paymenthighway.model.response;
+
+/**
+ *  Transaction Result response POJO.
+ *  Used to find out whether or not an uncommitted transaction succeeded, without actually committing (capturing) it.
+ */
+public class TransactionResultResponse extends AbstractTransactionOutcomeResponse {
+}

--- a/src/main/java/io/paymenthighway/model/response/TransactionStatus.java
+++ b/src/main/java/io/paymenthighway/model/response/TransactionStatus.java
@@ -33,6 +33,10 @@ public class TransactionStatus {
   @JsonProperty("cardholder_authentication")
   String cardholderAuthentication;
   String order;
+  @JsonProperty("committed")
+  private Boolean committed;
+  @JsonProperty("committed_amount")
+  private String committedAmount;
 
   public UUID getId() {
     return id;
@@ -100,5 +104,16 @@ public class TransactionStatus {
 
   public String getOrder() {
     return order;
+  }
+
+  public Boolean getCommitted() {
+    return committed;
+  }
+
+  /**
+   * @return The committed amount or null if transaction not committed
+   */
+  public String getCommittedAmount() {
+    return committedAmount;
   }
 }

--- a/src/test/java/io/paymenthighway/connect/FormAPIConnectionTest.java
+++ b/src/test/java/io/paymenthighway/connect/FormAPIConnectionTest.java
@@ -177,7 +177,7 @@ public class FormAPIConnectionTest {
     }
     // test that response is from success url
     assertNotNull(submitResponse);
-    assertTrue(submitResponse.contains("Payment Highway"));
+    assertTrue(submitResponse.contains("paymenthighway"));
 
     List<URI> redirectURIs = context.getRedirectLocations();
     assertEquals(2, redirectURIs.size());


### PR DESCRIPTION
…ransactionResult method for checking out whether or not a Form payment OR debit transaction with commit=false, succeeded without actually committing it. Add commit boolean and committedAmount to commit, transaction status and order search responses. Committed amount is especially useful if an amount smaller than the authorized payment was committed.